### PR TITLE
Implement v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 resolver = "2"
 
 members = ["embedded-sensors", "embedded-sensors-async"]
+
+[patch.crates-io]
+embedded-sensors = { path = "embedded-sensors" }

--- a/embedded-sensors-async/Cargo.toml
+++ b/embedded-sensors-async/Cargo.toml
@@ -1,6 +1,18 @@
 [package]
-name = "embedded-sensors-async"
-version = "0.1.0"
+authors = ["Kurtis Dinelle <t-kudinelle@microsoft.com>"]
+categories = ["embedded", "no-std", "hardware-support"]
 edition = "2021"
+rust-version = "1.79"
+keywords = ["hal", "sensors"]
+license = "MIT"
+name = "embedded-sensors-async"
+readme = "README.md"
+repository = "https://github.com/pop-project/embedded-sensors"
+version = "0.1.0"
+
+[features]
+defmt = ["dep:defmt", "embedded-sensors/defmt"]
 
 [dependencies]
+embedded-sensors = "0.1.0"
+defmt = { package = "defmt", version = "0.3.7", optional = true }

--- a/embedded-sensors-async/src/lib.rs
+++ b/embedded-sensors-async/src/lib.rs
@@ -1,1 +1,8 @@
+#![doc = include_str!("../README.md")]
+#![forbid(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
+#![allow(async_fn_in_trait)]
+
+pub mod sensor;
+pub mod temperature;

--- a/embedded-sensors-async/src/sensor.rs
+++ b/embedded-sensors-async/src/sensor.rs
@@ -1,0 +1,10 @@
+//! Async Sensor API
+//!
+//! This module predominantly contains error-handling generic to all sensors,
+//! however traits which apply to multiple kinds of sensors may be defined
+//! here as well as needed.
+//!
+//! Please see specific sensor-type modules for example usage
+//! (e.g. see temperature.rs for TemperatureSensor examples).
+
+pub use embedded_sensors::sensor::{Error, ErrorKind, ErrorType, Sample};

--- a/embedded-sensors-async/src/temperature.rs
+++ b/embedded-sensors-async/src/temperature.rs
@@ -1,0 +1,56 @@
+//! Async Temperature Sensor API
+//!
+//! This API provides generic methods for interfacing with temperature sensors specifically.
+//!
+//! # For HAL authors
+//!
+//! Here is an example for the implementation of the TemperatureSensor trait for a temperature sensor.
+//!
+//! ```
+//! use embedded_sensors_async::sensor;
+//! use embedded_sensors_async::temperature::TemperatureSensor;
+//!
+//! // A struct representing a temperature sensor.
+//! pub struct MyTempSensor {
+//!     // ...
+//! }
+//!
+//! #[derive(Clone, Copy, Debug)]
+//! pub enum Error {
+//!     // ...
+//! }
+//!
+//! impl sensor::Error for Error {
+//!     fn kind(&self) -> sensor::ErrorKind {
+//!         match *self {
+//!             // ...
+//!         }
+//!     }
+//! }
+//!
+//! impl sensor::ErrorType for MyTempSensor {
+//!     type Error = Error;
+//! }
+//!
+//! impl TemperatureSensor for MyTempSensor {
+//!     async fn temperature(&mut self) -> Result<sensor::Sample, Self::Error> {
+//!         // ...
+//!         Ok(42_000_000)
+//!     }
+//! }
+//! ```
+
+use crate::sensor::{ErrorType, Sample};
+
+/// Async Temperature Sensor methods.
+pub trait TemperatureSensor: ErrorType {
+    /// Returns a temperature sample in microdegrees Celsius.
+    async fn temperature(&mut self) -> Result<Sample, Self::Error>;
+}
+
+impl<T: TemperatureSensor + ?Sized> TemperatureSensor for &mut T {
+    #[inline]
+    async fn temperature(&mut self) -> Result<Sample, Self::Error> {
+        T::temperature(self).await
+    }
+}

--- a/embedded-sensors/Cargo.toml
+++ b/embedded-sensors/Cargo.toml
@@ -1,6 +1,17 @@
 [package]
-name = "embedded-sensors"
-version = "0.1.0"
+authors = ["Kurtis Dinelle <t-kudinelle@microsoft.com>"]
+categories = ["embedded", "no-std", "hardware-support"]
 edition = "2021"
+rust-version = "1.79"
+keywords = ["hal", "sensors"]
+license = "MIT"
+name = "embedded-sensors"
+readme = "README.md"
+repository = "https://github.com/pop-project/embedded-sensors"
+version = "0.1.0"
+
+[features]
+defmt = ["dep:defmt"]
 
 [dependencies]
+defmt = { package = "defmt", version = "0.3.7", optional = true }

--- a/embedded-sensors/src/lib.rs
+++ b/embedded-sensors/src/lib.rs
@@ -1,1 +1,7 @@
+#![doc = include_str!("../README.md")]
+#![forbid(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
+
+pub mod sensor;
+pub mod temperature;

--- a/embedded-sensors/src/sensor.rs
+++ b/embedded-sensors/src/sensor.rs
@@ -1,0 +1,89 @@
+//! Blocking Sensor API
+//!
+//! This module predominantly contains error-handling generic to all sensors,
+//! however traits which apply to multiple kinds of sensors may be defined
+//! here as well as needed.
+//!
+//! Please see specific sensor-type modules for example usage
+//! (e.g. see temperature.rs for TemperatureSensor examples).
+
+/// The underlying type representing a sensor sample.
+/// Sampling methods should return samples in finer units
+/// (e.g. microdegrees Celsius instead of degrees Celsius)
+/// to maintain precision if necessary.
+pub type Sample = i64;
+
+/// Sensor error.
+pub trait Error: core::fmt::Debug {
+    /// Convert error to a generic Sensor error kind.
+    ///
+    /// By using this method, Sensor errors freely defined by HAL implementations
+    /// can be converted to a set of generic Sensor errors upon which generic
+    /// code can act.
+    fn kind(&self) -> ErrorKind;
+}
+
+impl Error for core::convert::Infallible {
+    #[inline]
+    fn kind(&self) -> ErrorKind {
+        match *self {}
+    }
+}
+
+/// Sensor error kind.
+///
+/// This represents a common set of Sensor operation errors. HAL implementations are
+/// free to define more specific or additional error types. However, by providing
+/// a mapping to these common Sensor errors, generic code can still react to them.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// An error occurred on the underlying peripheral supporting the sensor.
+    /// e.g. An I2C error occurs for a digital sensor or an ADC error occurs for an analog sensor.
+    /// The original error may contain more information.
+    Peripheral,
+    /// The sensor is not yet ready to be sampled.
+    NotReady,
+    /// The sensor is currently saturated and sample may be invalid.
+    Saturated(Sample),
+    /// A different error occurred. The original error may contain more information.
+    Other,
+}
+
+impl Error for ErrorKind {
+    #[inline]
+    fn kind(&self) -> ErrorKind {
+        *self
+    }
+}
+
+impl core::fmt::Display for ErrorKind {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Peripheral => write!(
+                f,
+                "An error occured on the underlying peripheral. The original error may contain more informaton"
+            ),
+            Self::NotReady => write!(f, "Sensor is not yet ready to be sampled"),
+            Self::Saturated(_) => write!(f, "Sensor is saturated thus sample may be invalid"),
+            Self::Other => write!(
+                f,
+                "A different error occurred. The original error may contain more information"
+            ),
+        }
+    }
+}
+
+/// Sensor error type trait.
+///
+/// This just defines the error type, to be used by the other traits.
+pub trait ErrorType {
+    /// Error type
+    type Error: Error;
+}
+
+impl<T: ErrorType + ?Sized> ErrorType for &mut T {
+    type Error = T::Error;
+}

--- a/embedded-sensors/src/temperature.rs
+++ b/embedded-sensors/src/temperature.rs
@@ -1,0 +1,56 @@
+//! Blocking Temperature Sensor API
+//!
+//! This API provides generic methods for interfacing with temperature sensors specifically.
+//!
+//! # For HAL authors
+//!
+//! Here is an example for the implementation of the TemperatureSensor trait for a temperature sensor.
+//!
+//! ```
+//! use embedded_sensors::sensor;
+//! use embedded_sensors::temperature::TemperatureSensor;
+//!
+//! // A struct representing a temperature sensor.
+//! pub struct MyTempSensor {
+//!     // ...
+//! }
+//!
+//! #[derive(Clone, Copy, Debug)]
+//! pub enum Error {
+//!     // ...
+//! }
+//!
+//! impl sensor::Error for Error {
+//!     fn kind(&self) -> sensor::ErrorKind {
+//!         match *self {
+//!             // ...
+//!         }
+//!     }
+//! }
+//!
+//! impl sensor::ErrorType for MyTempSensor {
+//!     type Error = Error;
+//! }
+//!
+//! impl TemperatureSensor for MyTempSensor {
+//!     fn temperature(&mut self) -> Result<sensor::Sample, Self::Error> {
+//!         // ...
+//!         Ok(42_000_000)
+//!     }
+//! }
+//! ```
+
+use crate::sensor::{ErrorType, Sample};
+
+/// Blocking Temperature Sensor methods.
+pub trait TemperatureSensor: ErrorType {
+    /// Returns a temperature sample in microdegrees Celsius.
+    fn temperature(&mut self) -> Result<Sample, Self::Error>;
+}
+
+impl<T: TemperatureSensor + ?Sized> TemperatureSensor for &mut T {
+    #[inline]
+    fn temperature(&mut self) -> Result<Sample, Self::Error> {
+        T::temperature(self)
+    }
+}


### PR DESCRIPTION
This PR introduces the initial base for defining future traits for interfacing with all manners of sensors. The goal is to keep the crate small initially (instead of trying to design traits for all possible sensor configurations from the get-go) while allowing traits to easily be added as needed.

Currently, the sensor module mainly defines common error handling functionality shared by all sensors. If found necessary, traits that could apply to multiple subtypes of sensors (such as a threshold alert trait for temperature, humidity, etc sensors) should be defined in this module. Though due to the wide variety in behavior of sensors, such traits should be considered carefully before inclusion.

Sensor subtypes should then live within their own module (for example, temperature sensor traits live in the temperature.rs module). These traits should predominantly provide an appropriately named method for returning a sample from the sensor (e.g. don't name the method just "sample()" as a driver might implement both humidity and temperature traits which would both provide respective sampling methods).

After careful consideration, trait methods that return a sample should use the Sample type (currently defined as i64) in the sensor crate. This is to avoid imposing the use of floating points on users while avoiding the problems and difficulties of generic or implementation-defined return types. Return types should thus use finer units if necessary to maintain precision (for example, the TemperatureSensor trait returns samples in microdegrees Celsius instead of degrees Celsius).