### PR TITLE
Add alert-based traits

### DIFF
--- a/embedded-sensors-async/src/sensor.rs
+++ b/embedded-sensors-async/src/sensor.rs
@@ -1,10 +1,92 @@
 //! Async Sensor API
 //!
-//! This module predominantly contains error-handling generic to all sensors,
-//! however traits which apply to multiple kinds of sensors may be defined
-//! here as well as needed.
+//! This module contains error-handling and traits generic to all sensors.
 //!
-//! Please see specific sensor-type modules for example usage
+//! # For HAL authors
+//!
+//! Here is an example implementation of the ThresholdWait trait for a generic sensor.
+//!
+//! Please see specific sensor-type modules for addtional example usage
 //! (e.g. see temperature.rs for TemperatureSensor examples).
+//!
+//! ```
+//! use embedded_sensors_async::sensor::{self, ThresholdWait, Sample};
+//!
+//! struct MySensor {
+//!     // ...
+//! }
+//!
+//! #[derive(Clone, Copy, Debug)]
+//! pub enum Error {
+//!     // ...
+//! }
+//!
+//! impl sensor::Error for Error {
+//!     fn kind(&self) -> sensor::ErrorKind {
+//!         match *self {
+//!             // ...
+//!         }
+//!     }
+//! }
+//!
+//! impl sensor::ErrorType for MySensor {
+//!     type Error = Error;
+//! }
+//!
+//! impl ThresholdWait for MySensor {
+//!     async fn wait_for_sample_low(&mut self, threshold: Sample) -> Result<(), Self::Error> {
+//!         // Enable lower threshold alerts for sensor...
+//!         // Await alert (e.g. GPIO level change)...
+//!         // Disable alerts for sensor...
+//!
+//!         Ok(())
+//!     }
+//!
+//!     async fn wait_for_sample_high(&mut self, threshold: Sample) -> Result<(), Self::Error> {
+//!         // Enable upper threshold alerts for sensor...
+//!         // Await alert (e.g. await GPIO level change)...
+//!         // Disable alerts for sensor...
+//!
+//!         Ok(())
+//!     }
+//!
+//!     async fn wait_for_sample_out_of_range(
+//!         &mut self,
+//!         threshold_low: Sample,
+//!         threshold_high: Sample
+//!     ) -> Result<(), Self::Error> {
+//!         // Enable lower and upper threshold alerts for sensor...
+//!         // Await alert (e.g. await GPIO level change)...
+//!         // Disable alerts for sensor...
+//!
+//!         Ok(())
+//!     }
+//! }
+//! ```
 
 pub use embedded_sensors::sensor::{Error, ErrorKind, ErrorType, Sample};
+
+/// Asynchronously wait for sample measurements to exceed specified thresholds.
+pub trait ThresholdWait: ErrorType {
+    /// Wait for a sample to be measured below the given threshold.
+    /// The threshold should be in the same units as the units returned by the sensor's sampling method
+    /// (e.g. since the TemperatureSensor temperature() method returns microdegrees Celsius,
+    /// supplied threshold should also be in microdegrees Celsius).
+    async fn wait_for_sample_low(&mut self, threshold: Sample) -> Result<(), Self::Error>;
+
+    /// Wait for a sample to be measured above the given threshold.
+    /// The threshold should be in the same units as the units returned by the sensor's sampling method
+    /// (e.g. since the TemperatureSensor temperature() method returns microdegrees Celsius,
+    /// supplied threshold should also be in microdegrees Celsius).
+    async fn wait_for_sample_high(&mut self, threshold: Sample) -> Result<(), Self::Error>;
+
+    /// Wait for a sample to be measured below the given lower threshold or above the given upper threshold.
+    /// The thresholds should be in the same units as the units returned by the sensor's sampling method
+    /// (e.g. since the TemperatureSensor temperature() method returns microdegrees Celsius,
+    /// supplied threshold should also be in microdegrees Celsius).
+    async fn wait_for_sample_out_of_range(
+        &mut self,
+        threshold_low: Sample,
+        threshold_high: Sample,
+    ) -> Result<(), Self::Error>;
+}

--- a/embedded-sensors/src/sensor.rs
+++ b/embedded-sensors/src/sensor.rs
@@ -1,11 +1,8 @@
 //! Blocking Sensor API
 //!
-//! This module predominantly contains error-handling generic to all sensors,
-//! however traits which apply to multiple kinds of sensors may be defined
-//! here as well as needed.
+//! This module contains error-handling and traits generic to all sensors.
 //!
-//! Please see specific sensor-type modules for example usage
-//! (e.g. see temperature.rs for TemperatureSensor examples).
+//! Please see specific sensor-type modules for addtional example usage
 
 /// The underlying type representing a sensor sample.
 /// Sampling methods should return samples in finer units
@@ -47,6 +44,8 @@ pub enum ErrorKind {
     NotReady,
     /// The sensor is currently saturated and sample may be invalid.
     Saturated(Sample),
+    /// The sensor was configured with invalid input.
+    InvalidInput,
     /// A different error occurred. The original error may contain more information.
     Other,
 }
@@ -68,6 +67,7 @@ impl core::fmt::Display for ErrorKind {
             ),
             Self::NotReady => write!(f, "Sensor is not yet ready to be sampled"),
             Self::Saturated(_) => write!(f, "Sensor is saturated thus sample may be invalid"),
+            Self::InvalidInput => write!(f, "Sensor was configured with invalid input"),
             Self::Other => write!(
                 f,
                 "A different error occurred. The original error may contain more information"


### PR DESCRIPTION
This PR introduces a trait for sensors which support alerts/interrupt triggers. An enum is defined specifying the trigger type which the implementer can act upon. Additional trigger types may easily be added in the future as needed.

Currently, behavior for devices that don't support a specific trigger is implementation defined (perhaps to just panic). However a "NotSupported" error could be introduced which should be returned by the implementer if that is considered the better route.

PR #2 should likely be merged before this to avoid any hassles.