### PR TITLE
Make Sample type unique for each sensor type

### DIFF
--- a/embedded-sensors-async/Cargo.toml
+++ b/embedded-sensors-async/Cargo.toml
@@ -16,3 +16,4 @@ defmt = ["dep:defmt", "embedded-sensors/defmt"]
 [dependencies]
 embedded-sensors = "0.1.0"
 defmt = { package = "defmt", version = "0.3.7", optional = true }
+paste = "1.0.15"

--- a/embedded-sensors-async/src/temperature.rs
+++ b/embedded-sensors-async/src/temperature.rs
@@ -4,11 +4,11 @@
 //!
 //! # For HAL authors
 //!
-//! Here is an example for the implementation of the TemperatureSensor trait for a temperature sensor.
+//! Here is an example for the implementation of the TemperatureSensor and TemperatureThresholdWait traits for a temperature sensor.
 //!
 //! ```
 //! use embedded_sensors_async::sensor;
-//! use embedded_sensors_async::temperature::TemperatureSensor;
+//! use embedded_sensors_async::temperature::{TemperatureSensor, DegreesCelsius};
 //!
 //! // A struct representing a temperature sensor.
 //! pub struct MyTempSensor {
@@ -33,24 +33,58 @@
 //! }
 //!
 //! impl TemperatureSensor for MyTempSensor {
-//!     async fn temperature(&mut self) -> Result<sensor::Sample, Self::Error> {
+//!     async fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error> {
 //!         // ...
-//!         Ok(42_000_000)
+//!         Ok(42.0)
+//!     }
+//! }
+//!
+//! impl TemperatureThresholdWait for MyTempSensor {
+//!     async fn wait_for_temperature_low(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+//!         // Enable lower threshold alerts for sensor...
+//!         // Await alert (e.g. GPIO level change)...
+//!         // Disable alerts for sensor...
+//!
+//!         Ok(())
+//!     }
+//!
+//!     async fn wait_for_temperature_high(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+//!         // Enable upper threshold alerts for sensor...
+//!         // Await alert (e.g. await GPIO level change)...
+//!         // Disable alerts for sensor...
+//!
+//!         Ok(())
+//!     }
+//!
+//!     async fn wait_for_temperature_out_of_range(
+//!         &mut self,
+//!         threshold_low: DegreesCelsius,
+//!         threshold_high: DegreesCelsius
+//!     ) -> Result<(), Self::Error> {
+//!         // Enable lower and upper threshold alerts for sensor...
+//!         // Await alert (e.g. await GPIO level change)...
+//!         // Disable alerts for sensor...
+//!
+//!         Ok(())
 //!     }
 //! }
 //! ```
 
-use crate::sensor::{ErrorType, Sample};
+use crate::decl_threshold_wait;
+use crate::sensor::ErrorType;
+pub use embedded_sensors::temperature::DegreesCelsius;
 
 /// Async Temperature Sensor methods.
 pub trait TemperatureSensor: ErrorType {
-    /// Returns a temperature sample in microdegrees Celsius.
-    async fn temperature(&mut self) -> Result<Sample, Self::Error>;
+    /// Returns a temperature sample in degrees Celsius.
+    async fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error>;
 }
 
 impl<T: TemperatureSensor + ?Sized> TemperatureSensor for &mut T {
     #[inline]
-    async fn temperature(&mut self) -> Result<Sample, Self::Error> {
+    async fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error> {
         T::temperature(self).await
     }
 }
+
+decl_threshold_wait!(Temperature, DegreesCelsius, "degrees Celsius");

--- a/embedded-sensors/src/sensor.rs
+++ b/embedded-sensors/src/sensor.rs
@@ -3,12 +3,7 @@
 //! This module contains error-handling and traits generic to all sensors.
 //!
 //! Please see specific sensor-type modules for addtional example usage
-
-/// The underlying type representing a sensor sample.
-/// Sampling methods should return samples in finer units
-/// (e.g. microdegrees Celsius instead of degrees Celsius)
-/// to maintain precision if necessary.
-pub type Sample = i64;
+//! (e.g. see temperature.rs for TemperatureSensor examples).
 
 /// Sensor error.
 pub trait Error: core::fmt::Debug {
@@ -43,7 +38,7 @@ pub enum ErrorKind {
     /// The sensor is not yet ready to be sampled.
     NotReady,
     /// The sensor is currently saturated and sample may be invalid.
-    Saturated(Sample),
+    Saturated,
     /// The sensor was configured with invalid input.
     InvalidInput,
     /// A different error occurred. The original error may contain more information.
@@ -66,7 +61,7 @@ impl core::fmt::Display for ErrorKind {
                 "An error occured on the underlying peripheral. The original error may contain more informaton"
             ),
             Self::NotReady => write!(f, "Sensor is not yet ready to be sampled"),
-            Self::Saturated(_) => write!(f, "Sensor is saturated thus sample may be invalid"),
+            Self::Saturated => write!(f, "Sensor is saturated thus samples may be invalid"),
             Self::InvalidInput => write!(f, "Sensor was configured with invalid input"),
             Self::Other => write!(
                 f,

--- a/embedded-sensors/src/temperature.rs
+++ b/embedded-sensors/src/temperature.rs
@@ -8,7 +8,7 @@
 //!
 //! ```
 //! use embedded_sensors::sensor;
-//! use embedded_sensors::temperature::TemperatureSensor;
+//! use embedded_sensors::temperature::{TemperatureSensor, DegreesCelsius};
 //!
 //! // A struct representing a temperature sensor.
 //! pub struct MyTempSensor {
@@ -33,24 +33,27 @@
 //! }
 //!
 //! impl TemperatureSensor for MyTempSensor {
-//!     fn temperature(&mut self) -> Result<sensor::Sample, Self::Error> {
+//!     fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error> {
 //!         // ...
-//!         Ok(42_000_000)
+//!         Ok(42.0)
 //!     }
 //! }
 //! ```
 
-use crate::sensor::{ErrorType, Sample};
+use crate::sensor::ErrorType;
+
+/// Associates the units temperature samples are measured in with the underlying data type.
+pub type DegreesCelsius = f32;
 
 /// Blocking Temperature Sensor methods.
 pub trait TemperatureSensor: ErrorType {
-    /// Returns a temperature sample in microdegrees Celsius.
-    fn temperature(&mut self) -> Result<Sample, Self::Error>;
+    /// Returns a temperature sample in degrees Celsius.
+    fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error>;
 }
 
 impl<T: TemperatureSensor + ?Sized> TemperatureSensor for &mut T {
     #[inline]
-    fn temperature(&mut self) -> Result<Sample, Self::Error> {
+    fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error> {
         T::temperature(self)
     }
 }


### PR DESCRIPTION
After consideration, the underlying data type for samples measured by sensors should be specific to each sensor type (instead of declared for sensors as a whole). This gives more flexibility without making the data type completely generic/implementation defined, thus still allowing application code to be written in a generic manner.

`f32` was decided on as the appropriate type for temperature sensors as it is the most natural type. Trying to avoid use of floating-point is more trouble than it's worth because there's nothing preventing driver writers from using floats within their implementation which is where the real expense is anyway. Driver users can simply convert the `f32` sample to some integer-based format if they desire before further use.

The removal of the generic `Sample` type from the `sensor` module also required a change in how the threshold waiting trait is declared.

A generic/type associated approach for the input `Sample` requires the driver implementer to choose the appropriate type which is not ideal. Instead, the macro approach was used to create a version of the trait specific to the sensor type (to avoid a lot of code duplication in the future when more sensor types are added).

However, this may be macro abuse as this requires an external crate to concat identifiers, so open to suggestions for better approaches. The macro was expanded via `cargo expand` to verify it expands to what is expected and `cargo doc` was reviewed as well to ensure correctness.