### PR TITLE
Allow crates to be published

### DIFF
--- a/embedded-sensors-async/Cargo.toml
+++ b/embedded-sensors-async/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["Kurtis Dinelle <kdinelle@microsoft.com>"]
 categories = ["embedded", "no-std", "hardware-support"]
+description = "A HAL for various peripheral sensors (async)"
 edition = "2021"
 rust-version = "1.79"
 keywords = ["hal", "sensors"]

--- a/embedded-sensors-async/Cargo.toml
+++ b/embedded-sensors-async/Cargo.toml
@@ -15,6 +15,6 @@ version = "0.1.0"
 defmt = ["dep:defmt", "embedded-sensors-hal/defmt"]
 
 [dependencies]
-embedded-sensors-hal = { path = "../embedded-sensors" }
+embedded-sensors-hal = "0.1.0"
 defmt = { package = "defmt", version = "1.0.0", optional = true }
 paste = "1.0.15"

--- a/embedded-sensors/Cargo.toml
+++ b/embedded-sensors/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["Kurtis Dinelle <kdinelle@microsoft.com>"]
 categories = ["embedded", "no-std", "hardware-support"]
+description = "A HAL for various peripheral sensors"
 edition = "2021"
 rust-version = "1.79"
 keywords = ["hal", "sensors"]


### PR DESCRIPTION
Add description for both packages and depend on a version, rather than a path. This allows both packages to be published on crates.io.