### PR TITLE
Separate threshold trait into set and wait methods

### DIFF
--- a/embedded-sensors-async/Cargo.toml
+++ b/embedded-sensors-async/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "embedded-sensors-hal-async"
 readme = "README.md"
 repository = "https://github.com/OpenDevicePartnership/embedded-sensors"
-version = "0.1.0"
+version = "0.2.0"
 
 [features]
 defmt = ["dep:defmt", "embedded-sensors-hal/defmt"]

--- a/embedded-sensors-async/src/humidity.rs
+++ b/embedded-sensors-async/src/humidity.rs
@@ -41,38 +41,28 @@
 //! }
 //!
 //! impl RelativeHumidityThresholdWait for MyHumiditySensor {
-//!     async fn wait_for_relative_humidity_low(
+//!     async fn set_relative_humidity_threshold_low(
 //!         &mut self,
 //!         threshold: Percentage)
 //!     -> Result<(), Self::Error> {
-//!         // Enable lower threshold alerts for sensor...
-//!         // Await alert (e.g. GPIO level change)...
-//!         // Disable alerts for sensor...
-//!
+//!         // Write value to threshold low register of sensor...
 //!         Ok(())
 //!     }
 //!
-//!     async fn wait_for_relative_humidity_high(
+//!     async fn set_relative_humidity_threshold_high(
 //!         &mut self,
 //!         threshold: Percentage)
 //!     -> Result<(), Self::Error> {
-//!         // Enable upper threshold alerts for sensor...
-//!         // Await alert (e.g. await GPIO level change)...
-//!         // Disable alerts for sensor...
-//!
+//!         // Write value to threshold high register of sensor...
 //!         Ok(())
 //!     }
 //!
-//!     async fn wait_for_relative_humidity_out_of_range(
+//!     async fn wait_for_relative_humidity_threshold(
 //!         &mut self,
-//!         threshold_low: Percentage,
-//!         threshold_high: Percentage
-//!     ) -> Result<(), Self::Error> {
-//!         // Enable lower and upper threshold alerts for sensor...
-//!         // Await alert (e.g. await GPIO level change)...
-//!         // Disable alerts for sensor...
-//!
-//!         Ok(())
+//!     ) -> Result<Percentage, Self::Error> {
+//!         // Await threshold alert (e.g. await GPIO level change on ALERT pin)...
+//!         // Then return current relative humidity so caller can determine which threshold was crossed
+//!         self.relative_humidity().await
 //!     }
 //! }
 //! ```
@@ -94,4 +84,9 @@ impl<T: RelativeHumiditySensor + ?Sized> RelativeHumiditySensor for &mut T {
     }
 }
 
-decl_threshold_wait!(RelativeHumidity, Percentage, "percentage");
+decl_threshold_wait!(
+    RelativeHumidity,
+    RelativeHumiditySensor,
+    Percentage,
+    "percentage"
+);

--- a/embedded-sensors-async/src/sensor.rs
+++ b/embedded-sensors-async/src/sensor.rs
@@ -10,39 +10,32 @@ pub use embedded_sensors_hal::sensor::{Error, ErrorKind, ErrorType};
 /// Generates a threshold wait trait for the specified sensor type.
 #[macro_export]
 macro_rules! decl_threshold_wait {
-    ($SensorName:ident, $SampleType:ty, $unit:expr) => {
+    ($SensorName:ident, $SensorTrait:ident, $SampleType:ty, $unit:expr) => {
         paste::paste! {
-            #[doc = concat!(" Asynchronously wait for ", stringify!($SensorName), " measurements to exceed specified thresholds.")]
-            pub trait [<$SensorName ThresholdWait>]: ErrorType {
-                #[doc = concat!(" Wait for ", stringify!($SensorName), " to be measured below the given threshold (in ", $unit, ").")]
-                async fn [<wait_for_ $SensorName:snake _low>](&mut self, threshold: $SampleType) -> Result<(), Self::Error>;
+            #[doc = concat!(" Asynchronously set and wait for ", stringify!($SensorName), " measurements to exceed specified thresholds.")]
+            pub trait [<$SensorName ThresholdWait>]: $SensorTrait {
+                #[doc = concat!(" Set lower ", stringify!($SensorName), " threshold (in ", $unit, ").")]
+                async fn [<set_ $SensorName:snake _threshold_low>](&mut self, threshold: $SampleType) -> Result<(), Self::Error>;
 
-                #[doc = concat!(" Wait for ", stringify!($SensorName), " to be measured above the given threshold (in ", $unit, ").")]
-                async fn [<wait_for_ $SensorName:snake _high>](&mut self, threshold: $SampleType) -> Result<(), Self::Error>;
+                #[doc = concat!(" Set upper ", stringify!($SensorName), " threshold (in ", $unit, ").")]
+                async fn [<set_ $SensorName:snake _threshold_high>](&mut self, threshold: $SampleType) -> Result<(), Self::Error>;
 
-                #[doc = concat!(" Wait for ", stringify!($SensorName), " to be measured above or below the given high and low thresholds (in ", $unit, ").")]
-                async fn [<wait_for_ $SensorName:snake _out_of_range>](
-                    &mut self,
-                    threshold_low: $SampleType,
-                    threshold_high: $SampleType,
-                ) -> Result<(), Self::Error>;
+                #[doc = concat!(" Wait for ", stringify!($SensorName), " to be measured above or below the previously set high and low thresholds.")]
+                #[doc = concat!(" Returns the measured ", stringify!($SensorName), " at time threshold is exceeded (in ", $unit, ").")]
+                async fn [<wait_for_ $SensorName:snake _threshold>](&mut self) -> Result<$SampleType, Self::Error>;
             }
 
             impl<T: [<$SensorName ThresholdWait>] + ?Sized> [<$SensorName ThresholdWait>] for &mut T {
-                async fn [<wait_for_ $SensorName:snake _low>](&mut self, threshold: $SampleType) -> Result<(), Self::Error> {
-                    T::[<wait_for_ $SensorName:snake _low>](self, threshold).await
+                async fn [<set_ $SensorName:snake _threshold_low>](&mut self, threshold: $SampleType) -> Result<(), Self::Error> {
+                    T::[<set_ $SensorName:snake _threshold_low>](self, threshold).await
                 }
 
-                async fn [<wait_for_ $SensorName:snake _high>](&mut self, threshold: $SampleType) -> Result<(), Self::Error> {
-                    T::[<wait_for_ $SensorName:snake _high>](self, threshold).await
+                async fn [<set_ $SensorName:snake _threshold_high>](&mut self, threshold: $SampleType) -> Result<(), Self::Error> {
+                    T::[<set_ $SensorName:snake _threshold_high>](self, threshold).await
                 }
 
-                async fn [<wait_for_ $SensorName:snake _out_of_range>](
-                    &mut self,
-                    threshold_low: $SampleType,
-                    threshold_high: $SampleType,
-                ) -> Result<(), Self::Error> {
-                    T::[<wait_for_ $SensorName:snake _out_of_range>](self, threshold_low, threshold_high).await
+                async fn [<wait_for_ $SensorName:snake _threshold>](&mut self) -> Result<$SampleType, Self::Error> {
+                    T::[<wait_for_ $SensorName:snake _threshold>](self).await
                 }
             }
         }

--- a/embedded-sensors-async/src/temperature.rs
+++ b/embedded-sensors-async/src/temperature.rs
@@ -40,32 +40,20 @@
 //! }
 //!
 //! impl TemperatureThresholdWait for MyTempSensor {
-//!     async fn wait_for_temperature_low(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
-//!         // Enable lower threshold alerts for sensor...
-//!         // Await alert (e.g. GPIO level change)...
-//!         // Disable alerts for sensor...
-//!
+//!     async fn set_temperature_threshold_low(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+//!         // Write value to threshold low register of sensor...
 //!         Ok(())
 //!     }
 //!
-//!     async fn wait_for_temperature_high(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
-//!         // Enable upper threshold alerts for sensor...
-//!         // Await alert (e.g. await GPIO level change)...
-//!         // Disable alerts for sensor...
-//!
+//!     async fn set_temperature_threshold_high(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+//!         // Write value to threshold high register of sensor...
 //!         Ok(())
 //!     }
 //!
-//!     async fn wait_for_temperature_out_of_range(
-//!         &mut self,
-//!         threshold_low: DegreesCelsius,
-//!         threshold_high: DegreesCelsius
-//!     ) -> Result<(), Self::Error> {
-//!         // Enable lower and upper threshold alerts for sensor...
-//!         // Await alert (e.g. await GPIO level change)...
-//!         // Disable alerts for sensor...
-//!
-//!         Ok(())
+//!     async fn wait_for_temperature_threshold(&mut self) -> Result<DegreesCelsius, Self::Error> {
+//!         // Await threshold alert (e.g. await GPIO level change on ALERT pin)...
+//!         // Then return current temperature so caller can determine which threshold was crossed
+//!         self.temperature().await
 //!     }
 //! }
 //! ```
@@ -87,4 +75,9 @@ impl<T: TemperatureSensor + ?Sized> TemperatureSensor for &mut T {
     }
 }
 
-decl_threshold_wait!(Temperature, DegreesCelsius, "degrees Celsius");
+decl_threshold_wait!(
+    Temperature,
+    TemperatureSensor,
+    DegreesCelsius,
+    "degrees Celsius"
+);


### PR DESCRIPTION
The original `TemperatureThresholdWait` trait methods involved setting and waiting for thresholds within the same method. This PR changes this so that setting thresholds and waiting for thresholds are different methods:

<img width="491" alt="image" src="https://github.com/user-attachments/assets/81d2ad3f-7833-460e-ae97-e55ac6bda945" />

This breaks existing API, however since major version is still version 0, only minor version is incremented from `0.1.0` to `0.2.0` for `embedded-sensors-async`.

Resolves #19 