### PR TITLE
Remove threshold wait method and fix doc errors

### DIFF
--- a/embedded-sensors-async/Cargo.toml
+++ b/embedded-sensors-async/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "embedded-sensors-hal-async"
 readme = "README.md"
 repository = "https://github.com/OpenDevicePartnership/embedded-sensors"
-version = "0.2.0"
+version = "0.3.0"
 
 [features]
 defmt = ["dep:defmt", "embedded-sensors-hal/defmt"]

--- a/embedded-sensors-async/src/humidity.rs
+++ b/embedded-sensors-async/src/humidity.rs
@@ -5,7 +5,7 @@
 //! # For HAL authors
 //!
 //! Here is an example for the implementation of the RelativeHumiditySensor
-//! and RelativityHumidityThresholdWait traits for a humidity sensor.
+//! and RelativityHumidityThreshold traits for a humidity sensor.
 //!
 //! ```
 //! use embedded_sensors_hal_async::sensor;
@@ -40,7 +40,7 @@
 //!     }
 //! }
 //!
-//! impl RelativeHumidityThresholdWait for MyHumiditySensor {
+//! impl RelativeHumidityThreshold for MyHumiditySensor {
 //!     async fn set_relative_humidity_threshold_low(
 //!         &mut self,
 //!         threshold: Percentage)
@@ -56,18 +56,10 @@
 //!         // Write value to threshold high register of sensor...
 //!         Ok(())
 //!     }
-//!
-//!     async fn wait_for_relative_humidity_threshold(
-//!         &mut self,
-//!     ) -> Result<Percentage, Self::Error> {
-//!         // Await threshold alert (e.g. await GPIO level change on ALERT pin)...
-//!         // Then return current relative humidity so caller can determine which threshold was crossed
-//!         self.relative_humidity().await
-//!     }
 //! }
 //! ```
 
-use crate::decl_threshold_wait;
+use crate::decl_threshold;
 use crate::sensor::ErrorType;
 pub use embedded_sensors_hal::humidity::Percentage;
 
@@ -84,7 +76,7 @@ impl<T: RelativeHumiditySensor + ?Sized> RelativeHumiditySensor for &mut T {
     }
 }
 
-decl_threshold_wait!(
+decl_threshold!(
     RelativeHumidity,
     RelativeHumiditySensor,
     Percentage,

--- a/embedded-sensors-async/src/humidity.rs
+++ b/embedded-sensors-async/src/humidity.rs
@@ -9,7 +9,7 @@
 //!
 //! ```
 //! use embedded_sensors_hal_async::sensor;
-//! use embedded_sensors_hal_async::humidity::{RelativeHumiditySensor, Percentage};
+//! use embedded_sensors_hal_async::humidity::{RelativeHumiditySensor, RelativeHumidityThreshold, Percentage};
 //!
 //! // A struct representing a humidity sensor.
 //! pub struct MyHumiditySensor {

--- a/embedded-sensors-async/src/sensor.rs
+++ b/embedded-sensors-async/src/sensor.rs
@@ -7,35 +7,27 @@
 
 pub use embedded_sensors_hal::sensor::{Error, ErrorKind, ErrorType};
 
-/// Generates a threshold wait trait for the specified sensor type.
+/// Generates a threshold trait for the specified sensor type.
 #[macro_export]
-macro_rules! decl_threshold_wait {
+macro_rules! decl_threshold {
     ($SensorName:ident, $SensorTrait:ident, $SampleType:ty, $unit:expr) => {
         paste::paste! {
-            #[doc = concat!(" Asynchronously set and wait for ", stringify!($SensorName), " measurements to exceed specified thresholds.")]
-            pub trait [<$SensorName ThresholdWait>]: $SensorTrait {
+            #[doc = concat!(" Asynchronously set ", stringify!($SensorName), " thresholds.")]
+            pub trait [<$SensorName Threshold>]: $SensorTrait {
                 #[doc = concat!(" Set lower ", stringify!($SensorName), " threshold (in ", $unit, ").")]
                 async fn [<set_ $SensorName:snake _threshold_low>](&mut self, threshold: $SampleType) -> Result<(), Self::Error>;
 
                 #[doc = concat!(" Set upper ", stringify!($SensorName), " threshold (in ", $unit, ").")]
                 async fn [<set_ $SensorName:snake _threshold_high>](&mut self, threshold: $SampleType) -> Result<(), Self::Error>;
-
-                #[doc = concat!(" Wait for ", stringify!($SensorName), " to be measured above or below the previously set high and low thresholds.")]
-                #[doc = concat!(" Returns the measured ", stringify!($SensorName), " at time threshold is exceeded (in ", $unit, ").")]
-                async fn [<wait_for_ $SensorName:snake _threshold>](&mut self) -> Result<$SampleType, Self::Error>;
             }
 
-            impl<T: [<$SensorName ThresholdWait>] + ?Sized> [<$SensorName ThresholdWait>] for &mut T {
+            impl<T: [<$SensorName Threshold>] + ?Sized> [<$SensorName Threshold>] for &mut T {
                 async fn [<set_ $SensorName:snake _threshold_low>](&mut self, threshold: $SampleType) -> Result<(), Self::Error> {
                     T::[<set_ $SensorName:snake _threshold_low>](self, threshold).await
                 }
 
                 async fn [<set_ $SensorName:snake _threshold_high>](&mut self, threshold: $SampleType) -> Result<(), Self::Error> {
                     T::[<set_ $SensorName:snake _threshold_high>](self, threshold).await
-                }
-
-                async fn [<wait_for_ $SensorName:snake _threshold>](&mut self) -> Result<$SampleType, Self::Error> {
-                    T::[<wait_for_ $SensorName:snake _threshold>](self).await
                 }
             }
         }

--- a/embedded-sensors-async/src/temperature.rs
+++ b/embedded-sensors-async/src/temperature.rs
@@ -8,7 +8,7 @@
 //!
 //! ```
 //! use embedded_sensors_hal_async::sensor;
-//! use embedded_sensors_hal_async::temperature::{TemperatureSensor, DegreesCelsius};
+//! use embedded_sensors_hal_async::temperature::{TemperatureSensor, TemperatureThreshold, DegreesCelsius};
 //!
 //! // A struct representing a temperature sensor.
 //! pub struct MyTempSensor {

--- a/embedded-sensors-async/src/temperature.rs
+++ b/embedded-sensors-async/src/temperature.rs
@@ -4,7 +4,7 @@
 //!
 //! # For HAL authors
 //!
-//! Here is an example for the implementation of the TemperatureSensor and TemperatureThresholdWait traits for a temperature sensor.
+//! Here is an example for the implementation of the TemperatureSensor and TemperatureThreshold traits for a temperature sensor.
 //!
 //! ```
 //! use embedded_sensors_hal_async::sensor;
@@ -39,7 +39,7 @@
 //!     }
 //! }
 //!
-//! impl TemperatureThresholdWait for MyTempSensor {
+//! impl TemperatureThreshold for MyTempSensor {
 //!     async fn set_temperature_threshold_low(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
 //!         // Write value to threshold low register of sensor...
 //!         Ok(())
@@ -49,16 +49,10 @@
 //!         // Write value to threshold high register of sensor...
 //!         Ok(())
 //!     }
-//!
-//!     async fn wait_for_temperature_threshold(&mut self) -> Result<DegreesCelsius, Self::Error> {
-//!         // Await threshold alert (e.g. await GPIO level change on ALERT pin)...
-//!         // Then return current temperature so caller can determine which threshold was crossed
-//!         self.temperature().await
-//!     }
 //! }
 //! ```
 
-use crate::decl_threshold_wait;
+use crate::decl_threshold;
 use crate::sensor::ErrorType;
 pub use embedded_sensors_hal::temperature::DegreesCelsius;
 
@@ -75,7 +69,7 @@ impl<T: TemperatureSensor + ?Sized> TemperatureSensor for &mut T {
     }
 }
 
-decl_threshold_wait!(
+decl_threshold!(
     Temperature,
     TemperatureSensor,
     DegreesCelsius,

--- a/embedded-sensors/src/humidity.rs
+++ b/embedded-sensors/src/humidity.rs
@@ -11,7 +11,7 @@
 //! use embedded_sensors_hal::humidity::{RelativeHumiditySensor, Percentage};
 //!
 //! // A struct representing a humidity sensor.
-//! pub struct MyHumidityensor {
+//! pub struct MyHumiditySensor {
 //!     // ...
 //! }
 //!

--- a/embedded-sensors/src/temperature.rs
+++ b/embedded-sensors/src/temperature.rs
@@ -7,8 +7,8 @@
 //! Here is an example for the implementation of the TemperatureSensor trait for a temperature sensor.
 //!
 //! ```
-//! use embedded_sensors::sensor;
-//! use embedded_sensors::temperature::{TemperatureSensor, DegreesCelsius};
+//! use embedded_sensors_hal::sensor;
+//! use embedded_sensors_hal::temperature::{TemperatureSensor, DegreesCelsius};
 //!
 //! // A struct representing a temperature sensor.
 //! pub struct MyTempSensor {


### PR DESCRIPTION
After working with the traits in an async application context, it was discovered that a `threshold_wait` method is tricky because typically this would involve spawning a separate task to handle that. However, this would mean that the task needs to hold a mutex around the driver (assuming other tasks are also using the driver, for example a task which periodically samples the sensor). Thus, a `threshold_wait` method just blocks any other task indefinitely.

Having applications simply use the appropriate `embedded_hal_async::Wait` methods on a GPIO pin directly does not seem to be much of an inconvenience, therefore I decided to remove this method.

This PR also fixes a few documentation errors in a separate commit.