### PR TITLE
Split threshold trait

### DIFF
--- a/embedded-sensors-async/Cargo.toml
+++ b/embedded-sensors-async/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "embedded-sensors-hal-async"
 readme = "README.md"
 repository = "https://github.com/OpenDevicePartnership/embedded-sensors"
-version = "0.2.0"
+version = "0.3.0"
 
 [features]
 defmt = ["dep:defmt", "embedded-sensors-hal/defmt"]

--- a/embedded-sensors-async/src/humidity.rs
+++ b/embedded-sensors-async/src/humidity.rs
@@ -9,7 +9,10 @@
 //!
 //! ```
 //! use embedded_sensors_hal_async::sensor;
-//! use embedded_sensors_hal_async::humidity::{RelativeHumiditySensor, Percentage, RelativeHumidityThresholdWait};
+//! use embedded_sensors_hal_async::humidity::{
+//!     Percentage, RelativeHumiditySensor, RelativeHumidityThresholdSet,
+//!     RelativeHumidityThresholdWait,
+//! };
 //!
 //! // A struct representing a humidity sensor.
 //! pub struct MyHumiditySensor {
@@ -40,7 +43,7 @@
 //!     }
 //! }
 //!
-//! impl RelativeHumidityThresholdWait for MyHumiditySensor {
+//! impl RelativeHumidityThresholdSet for MyHumiditySensor {
 //!     async fn set_relative_humidity_threshold_low(
 //!         &mut self,
 //!         threshold: Percentage)
@@ -56,7 +59,9 @@
 //!         // Write value to threshold high register of sensor...
 //!         Ok(())
 //!     }
+//! }
 //!
+//! impl RelativeHumidityThresholdWait for MyHumiditySensor {
 //!     async fn wait_for_relative_humidity_threshold(
 //!         &mut self,
 //!     ) -> Result<Percentage, Self::Error> {
@@ -67,7 +72,7 @@
 //! }
 //! ```
 
-use crate::decl_threshold_wait;
+use crate::decl_threshold_traits;
 use crate::sensor::ErrorType;
 pub use embedded_sensors_hal::humidity::Percentage;
 
@@ -84,7 +89,7 @@ impl<T: RelativeHumiditySensor + ?Sized> RelativeHumiditySensor for &mut T {
     }
 }
 
-decl_threshold_wait!(
+decl_threshold_traits!(
     RelativeHumidity,
     RelativeHumiditySensor,
     Percentage,

--- a/embedded-sensors-async/src/sensor.rs
+++ b/embedded-sensors-async/src/sensor.rs
@@ -7,25 +7,28 @@
 
 pub use embedded_sensors_hal::sensor::{Error, ErrorKind, ErrorType};
 
-/// Generates a threshold wait trait for the specified sensor type.
+/// Generates threshold traits for the specified sensor type.
 #[macro_export]
-macro_rules! decl_threshold_wait {
+macro_rules! decl_threshold_traits {
     ($SensorName:ident, $SensorTrait:ident, $SampleType:ty, $unit:expr) => {
         paste::paste! {
-            #[doc = concat!(" Asynchronously set and wait for ", stringify!($SensorName), " measurements to exceed specified thresholds.")]
-            pub trait [<$SensorName ThresholdWait>]: $SensorTrait {
+            #[doc = concat!(" Asynchronously set ", stringify!($SensorName), " thresholds.")]
+            pub trait [<$SensorName ThresholdSet>]: $SensorTrait {
                 #[doc = concat!(" Set lower ", stringify!($SensorName), " threshold (in ", $unit, ").")]
                 async fn [<set_ $SensorName:snake _threshold_low>](&mut self, threshold: $SampleType) -> Result<(), Self::Error>;
 
                 #[doc = concat!(" Set upper ", stringify!($SensorName), " threshold (in ", $unit, ").")]
                 async fn [<set_ $SensorName:snake _threshold_high>](&mut self, threshold: $SampleType) -> Result<(), Self::Error>;
+            }
 
+            #[doc = concat!(" Asynchronously wait for ", stringify!($SensorName), " measurements to exceed specified thresholds.")]
+            pub trait [<$SensorName ThresholdWait>]: [<$SensorName ThresholdSet>] {
                 #[doc = concat!(" Wait for ", stringify!($SensorName), " to be measured above or below the previously set high and low thresholds.")]
                 #[doc = concat!(" Returns the measured ", stringify!($SensorName), " at time threshold is exceeded (in ", $unit, ").")]
                 async fn [<wait_for_ $SensorName:snake _threshold>](&mut self) -> Result<$SampleType, Self::Error>;
             }
 
-            impl<T: [<$SensorName ThresholdWait>] + ?Sized> [<$SensorName ThresholdWait>] for &mut T {
+            impl<T: [<$SensorName ThresholdSet>] + ?Sized> [<$SensorName ThresholdSet>] for &mut T {
                 async fn [<set_ $SensorName:snake _threshold_low>](&mut self, threshold: $SampleType) -> Result<(), Self::Error> {
                     T::[<set_ $SensorName:snake _threshold_low>](self, threshold).await
                 }
@@ -33,7 +36,9 @@ macro_rules! decl_threshold_wait {
                 async fn [<set_ $SensorName:snake _threshold_high>](&mut self, threshold: $SampleType) -> Result<(), Self::Error> {
                     T::[<set_ $SensorName:snake _threshold_high>](self, threshold).await
                 }
+            }
 
+            impl<T: [<$SensorName ThresholdWait>] + ?Sized> [<$SensorName ThresholdWait>] for &mut T {
                 async fn [<wait_for_ $SensorName:snake _threshold>](&mut self) -> Result<$SampleType, Self::Error> {
                     T::[<wait_for_ $SensorName:snake _threshold>](self).await
                 }

--- a/embedded-sensors-async/src/temperature.rs
+++ b/embedded-sensors-async/src/temperature.rs
@@ -8,7 +8,10 @@
 //!
 //! ```
 //! use embedded_sensors_hal_async::sensor;
-//! use embedded_sensors_hal_async::temperature::{TemperatureSensor, DegreesCelsius, TemperatureThresholdWait};
+//! use embedded_sensors_hal_async::temperature::{
+//!     DegreesCelsius, TemperatureSensor, TemperatureThresholdSet,
+//!     TemperatureThresholdWait,
+//! };
 //!
 //! // A struct representing a temperature sensor.
 //! pub struct MyTempSensor {
@@ -39,7 +42,7 @@
 //!     }
 //! }
 //!
-//! impl TemperatureThresholdWait for MyTempSensor {
+//! impl TemperatureThresholdSet for MyTempSensor {
 //!     async fn set_temperature_threshold_low(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
 //!         // Write value to threshold low register of sensor...
 //!         Ok(())
@@ -49,6 +52,9 @@
 //!         // Write value to threshold high register of sensor...
 //!         Ok(())
 //!     }
+//! }
+//!
+//! impl TemperatureThresholdWait for MyTempSensor {
 //!
 //!     async fn wait_for_temperature_threshold(&mut self) -> Result<DegreesCelsius, Self::Error> {
 //!         // Await threshold alert (e.g. await GPIO level change on ALERT pin)...
@@ -58,7 +64,7 @@
 //! }
 //! ```
 
-use crate::decl_threshold_wait;
+use crate::decl_threshold_traits;
 use crate::sensor::ErrorType;
 pub use embedded_sensors_hal::temperature::DegreesCelsius;
 
@@ -75,7 +81,7 @@ impl<T: TemperatureSensor + ?Sized> TemperatureSensor for &mut T {
     }
 }
 
-decl_threshold_wait!(
+decl_threshold_traits!(
     Temperature,
     TemperatureSensor,
     DegreesCelsius,


### PR DESCRIPTION
This splits the `Threshold` trait into two: one for setting thresholds and one for waiting on thresholds to be exceeded.

This is because it was discovered that having separate async tasks that share the same struct (which would implement multiple sensor traits), but one waits for thresholds and the other periodically samples the sensor for example, is problematic in that this is typically accomplished using a mutex, but the threshold wait task would lock the mutex preventing the sampling task from continuing.

However, it was also brought up that a threshold wait trait is still useful as there are cases where the user doesn't care to manually sample. But to avoid redundancy, the `ThresholdWait` trait is still dependent on the `ThresholdSet` trait to actually set the thresholds.

Depends on #27 