### PR TITLE
Add set_hysteresis method to threshold trait

### DIFF
--- a/embedded-sensors-async/src/humidity.rs
+++ b/embedded-sensors-async/src/humidity.rs
@@ -10,8 +10,8 @@
 //! ```
 //! use embedded_sensors_hal_async::sensor;
 //! use embedded_sensors_hal_async::humidity::{
-//!     Percentage, RelativeHumiditySensor, RelativeHumidityThresholdSet,
-//!     RelativeHumidityThresholdWait,
+//!     Percentage, RelativeHumidityHysteresis, RelativeHumiditySensor,
+//!     RelativeHumidityThresholdSet, RelativeHumidityThresholdWait,
 //! };
 //!
 //! // A struct representing a humidity sensor.
@@ -46,16 +46,16 @@
 //! impl RelativeHumidityThresholdSet for MyHumiditySensor {
 //!     async fn set_relative_humidity_threshold_low(
 //!         &mut self,
-//!         threshold: Percentage)
-//!     -> Result<(), Self::Error> {
+//!         threshold: Percentage
+//!     ) -> Result<(), Self::Error> {
 //!         // Write value to threshold low register of sensor...
 //!         Ok(())
 //!     }
 //!
 //!     async fn set_relative_humidity_threshold_high(
 //!         &mut self,
-//!         threshold: Percentage)
-//!     -> Result<(), Self::Error> {
+//!         threshold: Percentage
+//!     ) -> Result<(), Self::Error> {
 //!         // Write value to threshold high register of sensor...
 //!         Ok(())
 //!     }
@@ -68,6 +68,16 @@
 //!         // Await threshold alert (e.g. await GPIO level change on ALERT pin)...
 //!         // Then return current relative humidity so caller can determine which threshold was crossed
 //!         self.relative_humidity().await
+//!     }
+//! }
+//!
+//! impl RelativeHumidityHysteresis for MyHumiditySensor {
+//!     async fn set_relative_humidity_threshold_hysteresis(
+//!         &mut self,
+//!         hysteresis: Percentage
+//!     ) -> Result<(), Self::Error> {
+//!         // Write value to threshold hysteresis register of sensor...
+//!         Ok(())
 //!     }
 //! }
 //! ```

--- a/embedded-sensors-async/src/sensor.rs
+++ b/embedded-sensors-async/src/sensor.rs
@@ -28,6 +28,12 @@ macro_rules! decl_threshold_traits {
                 async fn [<wait_for_ $SensorName:snake _threshold>](&mut self) -> Result<$SampleType, Self::Error>;
             }
 
+            #[doc = concat!(" Asynchronously set ", stringify!($SensorName), " threshold hysteresis.")]
+            pub trait [<$SensorName Hysteresis>]: [<$SensorName ThresholdSet>] {
+                #[doc = concat!(" Set ", stringify!($SensorName), " threshold hysteresis (in ", $unit, ").")]
+                async fn [<set_ $SensorName:snake _threshold_hysteresis>](&mut self, hysteresis: $SampleType) -> Result<(), Self::Error>;
+            }
+
             impl<T: [<$SensorName ThresholdSet>] + ?Sized> [<$SensorName ThresholdSet>] for &mut T {
                 async fn [<set_ $SensorName:snake _threshold_low>](&mut self, threshold: $SampleType) -> Result<(), Self::Error> {
                     T::[<set_ $SensorName:snake _threshold_low>](self, threshold).await
@@ -41,6 +47,12 @@ macro_rules! decl_threshold_traits {
             impl<T: [<$SensorName ThresholdWait>] + ?Sized> [<$SensorName ThresholdWait>] for &mut T {
                 async fn [<wait_for_ $SensorName:snake _threshold>](&mut self) -> Result<$SampleType, Self::Error> {
                     T::[<wait_for_ $SensorName:snake _threshold>](self).await
+                }
+            }
+
+            impl<T: [<$SensorName Hysteresis>] + ?Sized> [<$SensorName Hysteresis>] for &mut T {
+                async fn [<set_ $SensorName:snake _threshold_hysteresis>](&mut self, hysteresis: $SampleType) -> Result<(), Self::Error> {
+                    T::[<set_ $SensorName:snake _threshold_hysteresis>](self, hysteresis).await
                 }
             }
         }

--- a/embedded-sensors-async/src/temperature.rs
+++ b/embedded-sensors-async/src/temperature.rs
@@ -9,8 +9,8 @@
 //! ```
 //! use embedded_sensors_hal_async::sensor;
 //! use embedded_sensors_hal_async::temperature::{
-//!     DegreesCelsius, TemperatureSensor, TemperatureThresholdSet,
-//!     TemperatureThresholdWait,
+//!     DegreesCelsius, TemperatureHysteresis, TemperatureSensor,
+//!     TemperatureThresholdSet, TemperatureThresholdWait,
 //! };
 //!
 //! // A struct representing a temperature sensor.
@@ -43,23 +43,40 @@
 //! }
 //!
 //! impl TemperatureThresholdSet for MyTempSensor {
-//!     async fn set_temperature_threshold_low(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+//!     async fn set_temperature_threshold_low(
+//!         &mut self,
+//!         threshold: DegreesCelsius
+//!     ) -> Result<(), Self::Error> {
 //!         // Write value to threshold low register of sensor...
 //!         Ok(())
 //!     }
 //!
-//!     async fn set_temperature_threshold_high(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+//!     async fn set_temperature_threshold_high(
+//!         &mut self,
+//!         threshold: DegreesCelsius
+//!     ) -> Result<(), Self::Error> {
 //!         // Write value to threshold high register of sensor...
 //!         Ok(())
 //!     }
 //! }
 //!
 //! impl TemperatureThresholdWait for MyTempSensor {
-//!
-//!     async fn wait_for_temperature_threshold(&mut self) -> Result<DegreesCelsius, Self::Error> {
+//!     async fn wait_for_temperature_threshold(
+//!         &mut self
+//!     ) -> Result<DegreesCelsius, Self::Error> {
 //!         // Await threshold alert (e.g. await GPIO level change on ALERT pin)...
 //!         // Then return current temperature so caller can determine which threshold was crossed
 //!         self.temperature().await
+//!     }
+//! }
+//!
+//! impl TemperatureHysteresis for MyTempSensor {
+//!     async fn set_temperature_threshold_hysteresis(
+//!         &mut self,
+//!         hysteresis: DegreesCelsius
+//!     ) -> Result<(), Self::Error> {
+//!         // Write value to threshold hysteresis register of sensor...
+//!         Ok(())
 //!     }
 //! }
 //! ```


### PR DESCRIPTION
This adds a method for setting hysteresis to the `SetThreshold` trait. Since hysteresis is tightly coupled to thresholds/limit alerts, it made sense to be included here instead of a separate trait. However, there are sensors that support threshold alerts but not configurable hysteresis, and in these cases the method should return an error signaling that it is not supported.

The main use case for hysteresis is for sensors that allow alerts to be configured in a comparator mode as opposed to purely interrupt mode. In this mode, the alert pin will stay active once the threshold is exceeded and only return to inactive once the measurement has fallen below the threshold limit + hysteresis. This is in contrast to interrupt modes where the alert pin will typically return to inactive once the alert has been processed, regardless of if the threshold is still currently exceeded.

Depends on #28 
Resolves #26 